### PR TITLE
Fix typo in UVChannel Javadoc

### DIFF
--- a/src/UVChannel.java
+++ b/src/UVChannel.java
@@ -147,7 +147,7 @@ public class UVChannel implements LNChannel, Serializable, Comparable<LNChannel>
         return node.balance;
     }
     /**
-     * Evaluate the current liquidity on channel peer side, considering the reserve to be mantained and the pending transactions
+     * Evaluate the current liquidity on channel peer side, considering the reserve to be maintained and the pending transactions
      * @return the amount of sats that could actually be received from peer
      */
     public synchronized int getLiquidity(String pubkey) {


### PR DESCRIPTION
## Summary
- fix spelling of "maintained" in `getLiquidity` Javadoc

## Testing
- `bash compile.sh`

------
https://chatgpt.com/codex/tasks/task_e_684f0785e2a08329bfe628923410f5d8